### PR TITLE
Fix(#19205): meilisearch destination incomplete indexing

### DIFF
--- a/airbyte-integrations/connectors/destination-meilisearch/Dockerfile
+++ b/airbyte-integrations/connectors/destination-meilisearch/Dockerfile
@@ -34,5 +34,5 @@ COPY destination_meilisearch ./destination_meilisearch
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=1.0.0
+LABEL io.airbyte.version=1.0.1
 LABEL io.airbyte.name=airbyte/destination-meilisearch

--- a/airbyte-integrations/connectors/destination-meilisearch/destination_meilisearch/destination.py
+++ b/airbyte-integrations/connectors/destination-meilisearch/destination_meilisearch/destination.py
@@ -3,7 +3,7 @@
 #
 
 
-from logging import Logger, getLogger
+from logging import Logger
 from typing import Any, Iterable, Mapping
 
 from airbyte_cdk.destinations import Destination
@@ -18,13 +18,12 @@ def get_client(config: Mapping[str, Any]) -> Client:
     return Client(host, api_key)
 
 
-logger = getLogger("airbyte")
-
-
 class DestinationMeilisearch(Destination):
     primary_key = "_ab_pk"
 
-    def write(self, config: Mapping[str, Any], configured_catalog: ConfiguredAirbyteCatalog, input_messages: Iterable[AirbyteMessage]) -> Iterable[AirbyteMessage]:
+    def write(
+        self, config: Mapping[str, Any], configured_catalog: ConfiguredAirbyteCatalog, input_messages: Iterable[AirbyteMessage]
+    ) -> Iterable[AirbyteMessage]:
         client = get_client(config=config)
 
         writer = MeiliWriter(client, self.primary_key)
@@ -49,8 +48,7 @@ class DestinationMeilisearch(Destination):
         try:
             client = get_client(config=config)
 
-            create_index_job = client.create_index(
-                "_airbyte", {"primaryKey": "id"})
+            create_index_job = client.create_index("_airbyte", {"primaryKey": "id"})
             client.wait_for_task(create_index_job.task_uid)
 
             add_documents_job = client.index("_airbyte").add_documents(

--- a/airbyte-integrations/connectors/destination-meilisearch/destination_meilisearch/destination.py
+++ b/airbyte-integrations/connectors/destination-meilisearch/destination_meilisearch/destination.py
@@ -47,8 +47,9 @@ class DestinationMeilisearch(Destination):
         try:
             client = get_client(config=config)
 
-            create_index_job = client.create_index("_airbyte", {"primaryKey": "id"})
-            client.wait_for_task(create_index_job["taskUid"])
+            create_index_job = client.create_index(
+                "_airbyte", {"primaryKey": "id"})
+            client.wait_for_task(create_index_job.task_uid)
 
             add_documents_job = client.index("_airbyte").add_documents(
                 [

--- a/airbyte-integrations/connectors/destination-meilisearch/destination_meilisearch/destination.py
+++ b/airbyte-integrations/connectors/destination-meilisearch/destination_meilisearch/destination.py
@@ -37,7 +37,7 @@ class DestinationMeilisearch(Destination):
             if message.type == Type.STATE:
                 writer.flush()
                 yield message
-            if message.type == Type.RECORD:
+            elif message.type == Type.RECORD:
                 record = message.record
                 writer.queue_write_operation(record.stream, record.data)
             else:

--- a/airbyte-integrations/connectors/destination-meilisearch/destination_meilisearch/writer.py
+++ b/airbyte-integrations/connectors/destination-meilisearch/destination_meilisearch/writer.py
@@ -2,35 +2,39 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from logging import getLogger
 from uuid import uuid4
 
 from meilisearch import Client
+from airbyte_cdk.models import AirbyteRecordMessage
 
 logger = getLogger("airbyte")
 
 
 class MeiliWriter:
-    write_buffer = []
     flush_interval = 50000
 
-    def __init__(self, client: Client, steam_name: str, primary_key: str):
+    def __init__(self, client: Client, streams: Iterable[str], primary_key: str):
         self.client = client
-        self.steam_name = steam_name
         self.primary_key = primary_key
+        self.streams = streams
+        self.write_buffer = dict((s, []) for s in streams)
 
-    def queue_write_operation(self, data: Mapping):
+    def queue_write_operation(self, message: AirbyteRecordMessage):
         random_key = str(uuid4())
-        self.write_buffer.append({**data, self.primary_key: random_key})
-        if len(self.write_buffer) == self.flush_interval:
+        self.write_buffer[message.stream].append(
+            {**message.data, self.primary_key: random_key})
+        if len(sum(self.write_buffer.values(), [])) == self.flush_interval:
             self.flush()
 
     def flush(self):
-        buffer_size = len(self.write_buffer)
+        buffer_size = len(sum(self.write_buffer.values(), []))
         if buffer_size == 0:
             return
-        logger.info(f"flushing {buffer_size} records")
-        response = self.client.index(self.steam_name).add_documents(self.write_buffer)
-        self.client.wait_for_task(response.task_uid, 1800000, 1000)
-        self.write_buffer.clear()
+        logger.info(f"flushing {buffer_size} records: {self.write_buffer}")
+        for stream_name in self.streams:
+            response = self.client.index(
+                stream_name).add_documents(self.write_buffer[stream_name])
+            self.client.wait_for_task(response.task_uid, 1800000, 1000)
+            self.write_buffer[stream_name].clear()

--- a/airbyte-integrations/connectors/destination-meilisearch/destination_meilisearch/writer.py
+++ b/airbyte-integrations/connectors/destination-meilisearch/destination_meilisearch/writer.py
@@ -22,8 +22,7 @@ class MeiliWriter:
 
     def queue_write_operation(self, stream_name: str, data: Mapping):
         random_key = str(uuid4())
-        self.write_buffer.append(
-            (stream_name, {**data, self.primary_key: random_key}))
+        self.write_buffer.append((stream_name, {**data, self.primary_key: random_key}))
         if len(self.write_buffer) == self.flush_interval:
             self.flush()
 
@@ -34,11 +33,10 @@ class MeiliWriter:
         logger.info(f"flushing {buffer_size} records: {self.write_buffer}")
 
         grouped_by_stream: defaultdict[str, list] = defaultdict(list)
-        for k, v in self.write_buffer:
-            grouped_by_stream[k].append(v)
+        for stream_name, message in self.write_buffer:
+            grouped_by_stream[stream_name].append(message)
 
         for (stream_name, data) in grouped_by_stream.items():
-            response = self.client.index(
-                stream_name).add_documents(data)
+            response = self.client.index(stream_name).add_documents(data)
             self.client.wait_for_task(response.task_uid, 1800000, 1000)
         self.write_buffer.clear()

--- a/airbyte-integrations/connectors/destination-meilisearch/destination_meilisearch/writer.py
+++ b/airbyte-integrations/connectors/destination-meilisearch/destination_meilisearch/writer.py
@@ -2,39 +2,43 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from collections.abc import Iterable, Mapping
+from collections import defaultdict
+from collections.abc import Mapping
 from logging import getLogger
 from uuid import uuid4
 
 from meilisearch import Client
-from airbyte_cdk.models import AirbyteRecordMessage
 
 logger = getLogger("airbyte")
 
 
 class MeiliWriter:
     flush_interval = 50000
+    write_buffer: list[tuple[str, Mapping]] = []
 
-    def __init__(self, client: Client, streams: Iterable[str], primary_key: str):
+    def __init__(self, client: Client, primary_key: str):
         self.client = client
         self.primary_key = primary_key
-        self.streams = streams
-        self.write_buffer = dict((s, []) for s in streams)
 
-    def queue_write_operation(self, message: AirbyteRecordMessage):
+    def queue_write_operation(self, stream_name: str, data: Mapping):
         random_key = str(uuid4())
-        self.write_buffer[message.stream].append(
-            {**message.data, self.primary_key: random_key})
-        if len(sum(self.write_buffer.values(), [])) == self.flush_interval:
+        self.write_buffer.append(
+            (stream_name, {**data, self.primary_key: random_key}))
+        if len(self.write_buffer) == self.flush_interval:
             self.flush()
 
     def flush(self):
-        buffer_size = len(sum(self.write_buffer.values(), []))
+        buffer_size = len(self.write_buffer)
         if buffer_size == 0:
             return
         logger.info(f"flushing {buffer_size} records: {self.write_buffer}")
-        for stream_name in self.streams:
+
+        grouped_by_stream: defaultdict[str, list] = defaultdict(list)
+        for k, v in self.write_buffer:
+            grouped_by_stream[k].append(v)
+
+        for (stream_name, data) in grouped_by_stream.items():
             response = self.client.index(
-                stream_name).add_documents(self.write_buffer[stream_name])
+                stream_name).add_documents(data)
             self.client.wait_for_task(response.task_uid, 1800000, 1000)
-            self.write_buffer[stream_name].clear()
+        self.write_buffer.clear()

--- a/airbyte-integrations/connectors/destination-meilisearch/destination_meilisearch/writer.py
+++ b/airbyte-integrations/connectors/destination-meilisearch/destination_meilisearch/writer.py
@@ -13,8 +13,8 @@ logger = getLogger("airbyte")
 
 
 class MeiliWriter:
-    flush_interval = 50000
     write_buffer: list[tuple[str, Mapping]] = []
+    flush_interval = 50000
 
     def __init__(self, client: Client, primary_key: str):
         self.client = client

--- a/airbyte-integrations/connectors/destination-meilisearch/integration_tests/integration_test.py
+++ b/airbyte-integrations/connectors/destination-meilisearch/integration_tests/integration_test.py
@@ -113,6 +113,6 @@ def test_write(config: Mapping, configured_catalog: ConfiguredAirbyteCatalog, cl
                      for i, stream_name in enumerate(streams)]
 
     destination = DestinationMeilisearch()
-    destination.write(config, configured_catalog, [
-                      *record_chunks, first_state_message])
+    list(destination.write(config, configured_catalog, [
+        *record_chunks, first_state_message]))
     assert records_count(client, streams) == 2

--- a/airbyte-integrations/connectors/destination-meilisearch/integration_tests/integration_test.py
+++ b/airbyte-integrations/connectors/destination-meilisearch/integration_tests/integration_test.py
@@ -32,7 +32,8 @@ def config_fixture() -> Mapping[str, Any]:
 
 @pytest.fixture(name="configured_catalog")
 def configured_catalog_fixture() -> ConfiguredAirbyteCatalog:
-    stream_schema = {"type": "object", "properties": {"string_col": {"type": "str"}, "int_col": {"type": "integer"}}}
+    stream_schema = {"type": "object", "properties": {
+        "string_col": {"type": "str"}, "int_col": {"type": "integer"}}}
 
     overwrite_stream = ConfiguredAirbyteStream(
         stream=AirbyteStream(
@@ -58,8 +59,8 @@ def client_fixture(config) -> Client:
     resp = client.create_index("_airbyte", {"primaryKey": "_ab_pk"})
     while True:
         time.sleep(0.2)
-        task = client.get_task(resp["taskUid"])
-        status = task["status"]
+        task = client.get_task(resp.task_uid)
+        status = task.status
         if status == "succeeded" or status == "failed":
             break
     return client
@@ -72,7 +73,8 @@ def test_check_valid_config(config: Mapping):
 
 def test_check_invalid_config():
     outcome = DestinationMeilisearch().check(
-        logging.getLogger("airbyte"), {"api_key": "not_a_real_key", "host": "https://www.meilisearch.com"}
+        logging.getLogger("airbyte"), {
+            "api_key": "not_a_real_key", "host": "https://www.meilisearch.com"}
     )
     assert outcome.status == Status.FAILED
 
@@ -83,7 +85,8 @@ def _state(data: Dict[str, Any]) -> AirbyteMessage:
 
 def _record(stream: str, str_value: str, int_value: int) -> AirbyteMessage:
     return AirbyteMessage(
-        type=Type.RECORD, record=AirbyteRecordMessage(stream=stream, data={"str_col": str_value, "int_col": int_value}, emitted_at=0)
+        type=Type.RECORD, record=AirbyteRecordMessage(
+            stream=stream, data={"str_col": str_value, "int_col": int_value}, emitted_at=0)
     )
 
 
@@ -95,8 +98,10 @@ def records_count(client: Client) -> int:
 def test_write(config: Mapping, configured_catalog: ConfiguredAirbyteCatalog, client: Client):
     overwrite_stream = configured_catalog.streams[0].stream.name
     first_state_message = _state({"state": "1"})
-    first_record_chunk = [_record(overwrite_stream, str(i), i) for i in range(2)]
+    first_record_chunk = [_record(overwrite_stream, str(i), i)
+                          for i in range(2)]
 
     destination = DestinationMeilisearch()
-    list(destination.write(config, configured_catalog, [*first_record_chunk, first_state_message]))
+    list(destination.write(config, configured_catalog,
+         [*first_record_chunk, first_state_message]))
     assert records_count(client) == 2

--- a/airbyte-integrations/connectors/destination-meilisearch/integration_tests/integration_test.py
+++ b/airbyte-integrations/connectors/destination-meilisearch/integration_tests/integration_test.py
@@ -98,12 +98,8 @@ def _record(stream: str, str_value: str, int_value: int) -> AirbyteMessage:
     )
 
 
-def records_count(client: Client, streams: Iterable[str]) -> int:
-    total = 0
-    for stream in streams:
-        total += client.index(stream).get_documents().total
-    return total
-
+def records_count(client: Client, stream: str) -> int:
+    return client.index(stream).get_documents().total
 
 def test_write(config: Mapping, configured_catalog: ConfiguredAirbyteCatalog, client: Client):
     streams = list(map(lambda s: s.stream.name, configured_catalog.streams))
@@ -115,4 +111,6 @@ def test_write(config: Mapping, configured_catalog: ConfiguredAirbyteCatalog, cl
     destination = DestinationMeilisearch()
     list(destination.write(config, configured_catalog, [
         *record_chunks, first_state_message]))
-    assert records_count(client, streams) == 2
+    
+    for stream in streams:
+        assert records_count(client, stream) == 1

--- a/airbyte-integrations/connectors/destination-meilisearch/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-meilisearch/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: destination
   definitionId: af7c921e-5892-4ff2-b6c1-4a5ab258fb7e
-  dockerImageTag: 1.0.0
+  dockerImageTag: 1.0.1
   dockerRepository: airbyte/destination-meilisearch
   githubIssueLabel: destination-meilisearch
   icon: meilisearch.svg

--- a/airbyte-integrations/connectors/destination-meilisearch/setup.py
+++ b/airbyte-integrations/connectors/destination-meilisearch/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-MAIN_REQUIREMENTS = ["airbyte-cdk", "meilisearch>=0.22.0"]
+MAIN_REQUIREMENTS = ["airbyte-cdk", "meilisearch>=0.28.2"]
 
 TEST_REQUIREMENTS = ["pytest~=6.1"]
 

--- a/airbyte-integrations/connectors/destination-meilisearch/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/destination-meilisearch/unit_tests/unit_test.py
@@ -11,23 +11,16 @@ from airbyte_cdk.models import AirbyteMessage, AirbyteRecordMessage, Type
 @patch("meilisearch.Client")
 def test_queue_write_operation(client):
     stream_name = "airbyte-testing"
-    writer = MeiliWriter(client, [stream_name], "primary_key")
-    writer.queue_write_operation(_record(stream_name))
-    assert len(writer.write_buffer.get("airbyte-testing")) == 1
+    writer = MeiliWriter(client, "primary_key")
+    writer.queue_write_operation(stream_name, {"a": "a"})
+    assert len(writer.write_buffer) == 1
 
 
 @patch("meilisearch.Client")
 def test_flush(client):
     stream_name = "airbyte-testing"
-    writer = MeiliWriter(client, [stream_name], "primary_key")
-    writer.queue_write_operation(_record(stream_name))
+    writer = MeiliWriter(client, "primary_key")
+    writer.queue_write_operation(stream_name, {"a": "a"})
     writer.flush()
     client.index.assert_called_once_with("airbyte-testing")
     client.wait_for_task.assert_called_once()
-
-
-def _record(stream: str) -> AirbyteMessage:
-    return AirbyteMessage(
-        type=Type.RECORD, record=AirbyteRecordMessage(
-            stream=stream, data={"str_col": "a", "int_col": 1}, emitted_at=0)
-    ).record

--- a/airbyte-integrations/connectors/destination-meilisearch/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/destination-meilisearch/unit_tests/unit_test.py
@@ -10,17 +10,15 @@ from airbyte_cdk.models import AirbyteMessage, AirbyteRecordMessage, Type
 
 @patch("meilisearch.Client")
 def test_queue_write_operation(client):
-    stream_name = "airbyte-testing"
     writer = MeiliWriter(client, "primary_key")
-    writer.queue_write_operation(stream_name, {"a": "a"})
+    writer.queue_write_operation("airbyte-testing", {"a": "a"})
     assert len(writer.write_buffer) == 1
 
 
 @patch("meilisearch.Client")
 def test_flush(client):
-    stream_name = "airbyte-testing"
     writer = MeiliWriter(client, "primary_key")
-    writer.queue_write_operation(stream_name, {"a": "a"})
+    writer.queue_write_operation("airbyte-testing", {"a": "a"})
     writer.flush()
     client.index.assert_called_once_with("airbyte-testing")
     client.wait_for_task.assert_called_once()


### PR DESCRIPTION
## What
Fixes #19205
All streams are written to first meilisearch index

## How
1. Loop over messages only once
2. Pass stream name to `queue_write_operation` method.
3. Within `flush` method, group `write_buffer` elements by stream name, and iterate to flush

## Recommended reading order
PR order is fine

## 🚨 User Impact 🚨##
Also bumps meilisearch dependency to latest version, as [v0.27.0](https://github.com/meilisearch/meilisearch-python/releases/tag/v0.27.0) includes breaking change to return type of `Task`


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added
